### PR TITLE
Add py_modules

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ license_files =
     LICENSE
 
 [options]
+py_modules = check_yamlschema
 python_requires = >=3.7
 install_requires =
     jsonschema


### PR DESCRIPTION
Required to make setuptools aware of single-file Python module.
