### PR TITLE
Pin jsonschema version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON := $(VENV)/bin/python
 
 
 $(PYTHON):
-	virtualenv $(VENV) --python python3.7
+	virtualenv $(VENV) --python python3.8
 	$(PYTHON) -m pip install --upgrade pip build twine
 
 requirements.txt: install

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = check-yamlschema
-version = 0.0.2
+version = 0.0.3
 description = A CLI and pre-commit hooks for jsonschema validation in YAML files with multiple documents
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -13,9 +13,9 @@ license_files =
 
 [options]
 py_modules = check_yamlschema
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
-    jsonschema
+    jsonschema<4.18.0
     pyyaml
     requests
 


### PR DESCRIPTION
This commit pin jsonschema to versions prior to 4.18.0 to avoid the
referencing library change that breaks automatic retrieval of remote
references.

Fix #3

Also remove Python 3.7 support that is now end of life.