### PR TITLE
Ignore missing properties for kubernetes and improve logging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,3 +15,5 @@ jobs:
       shell: bash
     - run: check-yamlschema -v tests/test.yaml .pre-commit-config.yaml .pre-commit-hooks.yaml .github/workflows/pre-commit.yml
       shell: bash
+    - run: check-yamlschema --k8s -v tests/test-k8s.yaml
+      shell: bash

--- a/tests/extraEnvs.json
+++ b/tests/extraEnvs.json
@@ -1,0 +1,29 @@
+{
+  "description": "Part of VMAgent jsonschema. CRD at https://github.com/VictoriaMetrics/helm-charts/blob/master/charts/victoria-metrics-operator/charts/crds/crds/crd.yaml",
+  "type": "object",
+  "properties": {
+    "extraEnvs": {
+      "description": "ExtraEnvs that will be passed to the application container",
+      "items": {
+        "description": "EnvVar represents an environment variable present in a Container.",
+        "properties": {
+          "name": {
+            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+            "type": "string"
+          },
+          "value": {
+            "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "x-kubernetes-preserve-unknown-fields": true,
+        "additionalProperties": false
+      },
+      "type": "array"
+    }
+  }
+}

--- a/tests/test-k8s.yaml
+++ b/tests/test-k8s.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=./extraEnvs.json
+extraEnvs:
+  - name: GOMEMLIMIT
+    valueFrom:
+      resourceFieldRef:
+        containerName: vmagent
+        divisor: "1"
+        resource: limits.memory


### PR DESCRIPTION
Changes:
 - verbose CLI flag enables debug logging,
 - print short information on failure, rather than traceback,
 - print absolute paths for schemas,
 - add k8s 'x-kubernetes-preserve-unknown-fields' handling.