### PR TITLE
Change schema download to use YAML format

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,7 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: pre-commit
 
-on:
+"on":
   pull_request:
   push:
     branches: [main]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: tests
 
-on:
+"on":
   pull_request:
   push:
     branches: [main]
@@ -15,7 +16,7 @@ jobs:
     - uses: actions/setup-python@v3
     - run: python -m pip install .
       shell: bash
-    - run: check-yamlschema -v tests/test.yaml .pre-commit-config.yaml .pre-commit-hooks.yaml .github/workflows/pre-commit.yml
+    - run: check-yamlschema -v tests/test.yaml tests/test-remote.yaml .pre-commit-config.yaml .pre-commit-hooks.yaml .github/workflows/pre-commit.yml
       shell: bash
     - run: check-yamlschema --k8s -v tests/test-k8s.yaml
       shell: bash

--- a/check_yamlschema.py
+++ b/check_yamlschema.py
@@ -82,7 +82,7 @@ def load_yaml_documents(file_path):
 def download_schema(schema_url):
     response = requests.get(schema_url)
     response.raise_for_status()
-    return response.json()
+    return yaml.safe_load(response.text)
 
 
 def validate_document(file, document, schema_url, validator):

--- a/tests/food.yaml
+++ b/tests/food.yaml
@@ -1,0 +1,39 @@
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false
+properties:
+  food:
+    items:
+      oneOf:
+      - additionalProperties: false
+        properties:
+          vegetables:
+            type: string
+        required:
+        - vegetables
+        type: object
+      - additionalProperties: false
+        properties:
+          fruits:
+            additionalProperties: false
+            properties:
+              citrics:
+                type: string
+              nuts:
+                type: string
+              sweets:
+                type: string
+              tropical:
+                type: string
+            required:
+            - citrics
+            - tropical
+            - nuts
+            - sweets
+            type: object
+        required:
+        - fruits
+        type: object
+    type: array
+required:
+- food
+type: object

--- a/tests/test-remote.yaml
+++ b/tests/test-remote.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/brynpickering/check-yamlschema/refs/heads/patch-1/tests/food.yaml
+food: # Some YAML document
+  - vegetables: tomatoes
+  - fruits:
+      citrics: oranges
+      tropical: bananas
+      nuts: peanuts
+      sweets: raisins
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/brynpickering/check-yamlschema/refs/heads/patch-1/tests/food.json
+food: # Some YAML document
+  - vegetables: tomatoes
+  - fruits:
+      citrics: oranges
+      tropical: bananas
+      nuts: peanuts
+      sweets: raisins

--- a/tests/test-remote.yaml
+++ b/tests/test-remote.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/brynpickering/check-yamlschema/refs/heads/patch-1/tests/food.yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/jmlrt/check-yamlschema/refs/heads/main/tests/food.yaml
 food: # Some YAML document
   - vegetables: tomatoes
   - fruits:
@@ -7,7 +7,7 @@ food: # Some YAML document
       nuts: peanuts
       sweets: raisins
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/brynpickering/check-yamlschema/refs/heads/patch-1/tests/food.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/jmlrt/check-yamlschema/refs/heads/main/tests/food.json
 food: # Some YAML document
   - vegetables: tomatoes
   - fruits:


### PR DESCRIPTION
For some reason, `requests.get().json()` was failing on [my schema](https://raw.githubusercontent.com/open-energy-transition/openmod-features/83a1dfa/schema/schema.yaml). It is probably because it starts with `$defs`. This is the standard output from a pydantic model json schema dump. `yaml.safe_load` should create the same result but doesn't fail in this case.